### PR TITLE
update mrjs landing to include the rest of the current samples in examples.mrjs.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,17 @@
 
                     <mr-div class="illustration">
                         <mr-a target="_blank" class="example-link"
+                            href="/examples/debug.html">Debugging</mr-a>
+                    </mr-div>
+
+                    <mr-div class="illustration">
+                        <mr-a target="_blank" class="example-link"
                             href="/examples/embed.html">Embed</mr-a>
+                    </mr-div>
+
+                    <mr-div class="illustration">
+                        <mr-a target="_blank" class="example-link"
+                            href="/examples/images.html">Images</mr-a>
                     </mr-div>
 
                     <mr-div class="illustration">
@@ -151,6 +161,11 @@
                     <mr-div class="illustration">
                         <mr-a target="_blank" class="example-link"
                             href="/examples/skybox.html">Skybox</mr-a>
+                    </mr-div>
+                    
+                    <mr-div class="illustration">
+                        <mr-a target="_blank" class="example-link"
+                             href="/examples/video.html">Video</mr-a>
                     </mr-div>
 
                 </mr-div>

--- a/index.html
+++ b/index.html
@@ -130,27 +130,27 @@
 
                     <mr-div class="illustration">
                         <mr-a target="_blank" class="example-link"
-                            href="https://examples.mrjs.io/examples/anchors.html">Anchoring</mr-a>
+                            href="/examples/anchors.html">Anchoring</mr-a>
                     </mr-div>
 
                     <mr-div class="illustration">
                         <mr-a target="_blank" class="example-link"
-                            href="https://examples.mrjs.io/examples/audio.html">Audio</mr-a>
+                            href="/examples/audio.html">Audio</mr-a>
                     </mr-div>
 
                     <mr-div class="illustration">
                         <mr-a target="_blank" class="example-link"
-                            href="https://examples.mrjs.io/examples/embed.html">Embed</mr-a>
+                            href="/examples/embed.html">Embed</mr-a>
                     </mr-div>
 
                     <mr-div class="illustration">
                         <mr-a target="_blank" class="example-link"
-                            href="https://examples.mrjs.io/examples/models.html">Models</mr-a>
+                            href="/examples/models.html">Models</mr-a>
                     </mr-div>
 
                     <mr-div class="illustration">
                         <mr-a target="_blank" class="example-link"
-                            href="https://examples.mrjs.io/examples/skybox.html">Skybox</mr-a>
+                            href="/examples/skybox.html">Skybox</mr-a>
                     </mr-div>
 
                 </mr-div>


### PR DESCRIPTION
- allows the links to work nicely with localhost:8080 and with the full mrjs.io link
- updates for index.html to be the main landing page for mrjs.io and for its samples/testing pages

this change is part of a step for https://github.com/Volumetrics-io/mrjs/pull/530